### PR TITLE
latest threads bug fix

### DIFF
--- a/inc/plugins/adv_sidebox/modules/latest_threads/adv_sidebox_module.php
+++ b/inc/plugins/adv_sidebox/modules/latest_threads/adv_sidebox_module.php
@@ -82,7 +82,7 @@ function latest_threads_asb_build_template($settings)
 {
 	global $latest_threads, $threadlist, $gotounread; // <-- important!
 	
-	global $db, $mybb, $templates, $lang, $cache, $thread, $theme;
+	global $db, $mybb, $templates, $lang, $cache, $theme;
 	
 	// Load custom language phrases
 	if (!$lang->adv_sidebox)


### PR DESCRIPTION
- oryginally reported by - gemini at mybb forums.
- bug - when latest threads addon enabled, attachments are not displayed
  in post.
- cause - $thread variable overwritten by latest thread addon.
- action taken - $thread variable scope within addon changed.
- refferenced by avril-gh/Advanced-Sidebox#2 for
  WildcardSearch/Advanced-Sidebox#27

fixed, test. latest threads addon appearance - correct, attachment appearance - correct.
![issue2pic](https://f.cloud.github.com/assets/3224132/118164/be9967a4-6c69-11e2-8cd7-08966557d352.jpg)
