### PR TITLE
New Avatar Constraint on Maintain Aspect Ratio

### DIFF
--- a/Upload/inc/plugins/asb/modules/whosonline.php
+++ b/Upload/inc/plugins/asb/modules/whosonline.php
@@ -32,7 +32,7 @@ function asb_whosonline_info()
 	return array(
 		"title" => $lang->asb_wol,
 		"description" => $lang->asb_wol_desc,
-		"version" => "1.4.2",
+		"version" => "1.4.3",
 		"wrap_content" => true,
 		"xmlhttp" => true,
 		"settings" =>	array(
@@ -88,7 +88,7 @@ function asb_whosonline_info()
 				</tr>
 				<tr>
 					<td class="trow2">
-						<table>
+						<table style="width: 100%; text-align: center;">
 							<tr>
 								{\$onlinemembers}
 							</tr>


### PR DESCRIPTION
This may be a matter of preference, but it is an edit that I put in whosonline.php for my own website since I prefer it, and I thought I would share the code so you can see if you also prefer it. :)

The default method for maintaining aspect ratio (constraining by width) can result in skewed avatar dimensions for avatars that are significantly higher than they are wide (i.e. an unusually high avatar appears much larger than an unusually wide avatar).

Instead, I prefer to have the script check the avatar's dimensions, and constrain it by its largest dimension. So if the avatar is higher than it is wide, it will be constrained by height. If it is wider than it is high, it will be constrained by width. This avoids avatar stretching while getting closer to the benefit of constraining by both dimensions (uniform avatars).

I also changed $db->query to $db->write_query, since the MyBB Docs indicate that write_query is now preferred (http://docs.mybb.com/Database_Constants.html). Though if you have reasons I'm not aware of for using $db->query, obviously you can ignore that change.
