### PR TITLE
Fix to stretched avatar display

### DIFF
--- a/Upload/inc/plugins/asb/modules/whosonline.php
+++ b/Upload/inc/plugins/asb/modules/whosonline.php
@@ -287,7 +287,7 @@ function asb_whosonline_get_online_members($settings, $width)
 					}
 
 					$user_avatar = <<<EOF
-<img style="width: 100%;{$avatar_width_style}{$avatar_height_style}" src="{$avatar_filename}" alt="{$lang->asb_wol_avatar}" title="{$user['username']}'s {$lang->asb_wol_profile}"/>
+<img style="{$avatar_width_style}{$avatar_height_style}" src="{$avatar_filename}" alt="{$lang->asb_wol_avatar}" title="{$user['username']}'s {$lang->asb_wol_profile}"/>
 EOF;
 
 					// if this is the last allowable avatar (conforming to ACP settings)


### PR DESCRIPTION
I thought we had this one covered, but it appears not. On Chrome, if "Maintain Aspect Ratio" is enabled and there are more than one avatar on a line, the avatars preceding the final avatar of the line are stretched to fit. Firefox and Internet Explorer do not do this. The "width: 100%" style on the image appears to be the culprit. Removing that style entry does not appear to change the way it displays on Firefox or Internet Explorer, even if "Maintain Aspect Ratio" is disabled.
