### PR TITLE
3.1.14 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,54 @@
-## Advanced-Sidebox 3.1.13
+## Advanced-Sidebox 3.1.14
 
 <p align="center">
   <img title="Advanced Sidebox Logo" alt="Advanced Sidebox Logo" src="http://i.imgur.com/4QWLq5V.png" />
 </p>
 
-*A plugin for MyBB forums that displays custom boxes on various forum pages.*
+<p align="center">
+A plugin for MyBB forums that displays custom boxes on various forum pages.
+</p>
 
-This plugin seeks to give the admin more options when adding side boxes to the forum and allow control in a more intuitive way. This plugin edits the template cache and does not modify your forum's templates-- therefore it does not work with every theme but *is* designed to work with most.
+ASB is ***the*** side box plugin for MyBB forums. It is versatile, powerful, and built using the advice of its users.
 
-## Features
+## Features:
 
-* Now add and edit script definitions to further customize ASB! Also now compatible with Page Manager scripts.
-* New add-on module added to the core: Recent Posts (AJAX Ready)
-* AJAX Refresh now integrated into the core and five of the core modules (latest threads, PMs, random quotes, staff on-line and who's on-line avatar lists)!
-* New Improved Drag and Drop Interface!
-* Admin can control many settings for where and how side boxes display
-* Eight scripts available! (Index, Forum, Thread, Member Profiles, Member List, Forum Team, Statistics and Portal)
-* Choose one of many default presets with updated content or create semi-static custom boxes with HTML and template variables
-* Import/Export custom boxes to share and backup your work
-* Control which scripts side boxes display on
-* Individual side box settings
-* Extensive user group permissions for side boxes
-* Now supports CodePress
-* Newly redesigned On-line Staff module
-* Context-sensitive help for ACP pages
+* create an **unlimited** amount of side **boxes** on the left, right or both
+* **add** side boxes **to** almost **any page**
+* side boxes can be create**d using core modules** (listed below) or **static HTML** created by the admin
+* static HTML (termed **custom** side **boxes**) may be **imported**/**exported** to XML to backup, restore and share
+* side boxes expand/collapse just like the MyBB core windows
+* JavaScript **visibility toggle** icons for columns (uses **cookies** to remember states)
+* intuitive, **drag and drop**, side box management interface in ACP
+* context-sensitive **help pages** in ACP
+* easily **extensible** from single file modules for **third-party** developers and the hobbyist admin
+* **CodeMirror** supported when editing custom side boxes (if enabled in ACP)
+* compatible with **Page Manager** pages and custom scripts
+* **AJAX Update** integrated into the core and eight of the core modules! (listed below)
+
+
+## Controls:
+
+* which user **group(s)** the side boxes display for
+* which **script(s)** the side boxes display in
+* which **theme(s)** the side boxes display on
+* disable the plugin for **specific themes**
+* admin **option to allow users to disable side boxes** globally from usercp.php
+
+
+## Current default side box types available:
+
+* ![New](https://i.imgur.com/FMH0S6f.png) Birthdays
+* ![New](https://i.imgur.com/FMH0S6f.png) Forum Age ![AJAX-ready](http://i.imgur.com/nw832ed.png)
+* Forum Goals ![AJAX-ready](http://i.imgur.com/nw832ed.png)
+* Top Poster
+* Slideshow
+* Recent Posts ![AJAX-ready](http://i.imgur.com/nw832ed.png)
+* Who's Online ![AJAX-ready](http://i.imgur.com/nw832ed.png)
+* Latest Threads ![AJAX-ready](http://i.imgur.com/nw832ed.png)
+* Welcome
+* Statistics
+* Private Messages ![AJAX-ready](http://i.imgur.com/nw832ed.png)
+* Search
+* Random Quotes ![AJAX-ready](http://i.imgur.com/nw832ed.png)
+* Staff Online ![AJAX-ready](http://i.imgur.com/nw832ed.png)
+* You can also create your own custom box types with static content

--- a/Upload/inc/plugins/asb.php
+++ b/Upload/inc/plugins/asb.php
@@ -15,7 +15,7 @@ if (!defined('IN_MYBB')) {
 // for modules
 define('IN_ASB', true);
 define('ASB_MODULES_DIR', MYBB_ROOT . 'inc/plugins/asb/modules');
-define('ASB_VERSION', '3.1.13');
+define('ASB_VERSION', '3.1.14');
 define('ASB_CUSTOM_VERSION', '2.0');
 define('ASB_SCRIPT_VERSION', '2.0');
 

--- a/Upload/inc/plugins/asb/functions.php
+++ b/Upload/inc/plugins/asb/functions.php
@@ -579,22 +579,23 @@ function asb_get_all_themes($full = false)
 {
 	global $db;
 
-	if ($full != true) {
-		$excluded_themes = asb_get_excluded_themes(true);
+	static $themeList;
+
+	if (!is_array($themeList)) {
+		if ($full != true) {
+			$excluded_themes = asb_get_excluded_themes(true);
+		}
+
+		// get all the themes that are not MasterStyles
+		$query = $db->simple_select('themes', 'tid, name', "NOT pid='0'{$excluded_themes}");
+
+		$themeList = array();
+		while ($thisTheme = $db->fetch_array($query)) {
+			$themeList[$thisTheme['tid']] = $thisTheme['name'];
+		}
 	}
 
-	// get all the themes that are not MasterStyles
-	$query = $db->simple_select('themes', 'tid, name', "NOT pid='0'{$excluded_themes}");
-
-	$return_array = array();
-	if ($db->num_rows($query) == 0) {
-		return $return_array;
-	}
-
-	while ($this_theme = $db->fetch_array($query)) {
-		$return_array[$this_theme['tid']] = $this_theme['name'];
-	}
-	return $return_array;
+	return $themeList;
 }
 
 ?>

--- a/Upload/inc/plugins/asb/functions_acp.php
+++ b/Upload/inc/plugins/asb/functions_acp.php
@@ -164,17 +164,12 @@ EOF;
  * @param  int id
  * @return string html
  */
-function asb_build_permissions_table($id)
+function asb_build_permissions_table($sidebox)
 {
-	if (!$id) {
-		return false;
-	}
-
 	global $lang, $all_scripts;
 
-	$sidebox = new SideboxObject($id);
-
-	if (!$sidebox->isValid()) {
+	if ($sidebox instanceof SideboxObject == false ||
+		!$sidebox->isValid()) {
 		return $lang->asb_invalid_sidebox;
 	}
 
@@ -367,7 +362,8 @@ EOF;
 function asb_build_sidebox_info($sidebox, $wrap = true, $ajax = false)
 {
 	// must be a valid object
-	if ($sidebox instanceof SideboxObject == false) {
+	if ($sidebox instanceof SideboxObject == false ||
+		!$sidebox->isValid()) {
 		return false;
 	}
 
@@ -379,7 +375,7 @@ function asb_build_sidebox_info($sidebox, $wrap = true, $ajax = false)
 	$module = $sidebox->get('box_type');
 
 	// visibility table
-	$visibility = '<span class="custom info">' . asb_build_permissions_table($id) . '</span>';
+	$visibility = '<span class="custom info">' . asb_build_permissions_table($sidebox) . '</span>';
 
 	// edit link
 	$edit_link = $html->url(array("action" => 'edit_box', "id" => $id, "addon" => $module, "pos" => $pos));

--- a/Upload/inc/plugins/asb/functions_acp.php
+++ b/Upload/inc/plugins/asb/functions_acp.php
@@ -198,21 +198,25 @@ function asb_build_visibility_rows($sidebox, &$group_count, &$global)
 {
 	global $db, $lang, $all_scripts;
 
+	static $options;
+
 	if (!is_array($all_scripts) ||
 		empty($all_scripts)) {
 		return $lang->asb_no_active_scripts;
 	}
 
-	// prepare options for which groups
-	$options = array($lang->asb_guests);
-	$groups = array();
+	if (!is_array($options)) {
+		// prepare options for which groups
+		$options = array($lang->asb_guests);
 
-	// look for all groups except Super Admins
-	$query = $db->simple_select('usergroups', 'gid, title', "gid != '1'", array('order_by' => 'gid'));
-	while ($usergroup = $db->fetch_array($query)) {
-		// store the titles by group id
-		$options[(int)$usergroup['gid']] = $usergroup['title'];
+		// look for all groups except Super Admins
+		$query = $db->simple_select('usergroups', 'gid, title', "gid != '1'", array('order_by' => 'gid'));
+		while ($usergroup = $db->fetch_array($query)) {
+			// store the titles by group id
+			$options[(int)$usergroup['gid']] = $usergroup['title'];
+		}
 	}
+
 	$group_count = $all_group_count = count($options);
 
 	$groups = $sidebox->get('groups');

--- a/Upload/inc/plugins/asb/functions_addon.php
+++ b/Upload/inc/plugins/asb/functions_addon.php
@@ -17,7 +17,7 @@ function asb_strip_quotes($message)
 {
 	// Assign pattern and replace values.
 	$pattern = array(
-		"#\[quote=([\"']|&quot;|)(.*?)(?:\\1)(.*?)(?:[\"']|&quot;)?\](.*?)\[/quote\](\r\n?|\n?)#esi",
+		"#\[quote=([\"']|&quot;|)(.*?)(?:\\1)(.*?)(?:[\"']|&quot;)?\](.*?)\[/quote\](\r\n?|\n?)#si",
 		"#\[quote\](.*?)\[\/quote\](\r\n?|\n?)#si",
 		"#\[\/quote\](\r\n?|\n?)#si"
 	);
@@ -26,11 +26,7 @@ function asb_strip_quotes($message)
 		$message = preg_replace($pattern, '', $message, -1, $count);
 	} while($count);
 
-	$find = array(
-		"#(\r\n*|\n*)<\/cite>(\r\n*|\n*)#",
-		"#(\r\n*|\n*)<\/blockquote>#"
-	);
-	return preg_replace($find, '', $message);
+	return $message;
 }
 
 /**

--- a/Upload/inc/plugins/asb/modules/birthdays.php
+++ b/Upload/inc/plugins/asb/modules/birthdays.php
@@ -138,9 +138,12 @@ function asb_birthdays_get_birthdays($args)
 	}
 
 	$userAvatarList = implode(',', $userAvatarList);
-	$query = $db->simple_select('users', 'uid, avatar, avatardimensions', "uid IN({$userAvatarList})");
-	while ($user = $db->fetch_array($query)) {
-		$userAvatars[$user['uid']] = format_avatar($user['avatar'], $user['avatardimensions'], '20x20');
+	if (!empty($userAvatarList)) {
+		$query = $db->simple_select('users', 'uid, avatar, avatardimensions', "uid IN({$userAvatarList})");
+
+		while ($user = $db->fetch_array($query)) {
+			$userAvatars[$user['uid']] = format_avatar($user['avatar'], $user['avatardimensions'], '20x20');
+		}
 	}
 
 	$alreadyDone = array();

--- a/Upload/inc/plugins/asb/modules/welcome_box.php
+++ b/Upload/inc/plugins/asb/modules/welcome_box.php
@@ -30,7 +30,7 @@ function asb_welcome_box_info()
 		'title' => $lang->asb_welcome,
 		'description' => $lang->asb_welcome_desc,
 		'wrap_content' => true,
-		'version' => '1.3.2',
+		'version' => '1.3.3',
 		'compatibility' => '2.1',
 		'templates' => array(
 			array(
@@ -62,9 +62,9 @@ EOF
 				<br />
 				<form method="post" action="{\$mybb->settings[\'bburl\']}/member.php"><input type="hidden" name="action" value="do_login"/>
 					<input type="hidden" name="url" value="member.php"/>
-					{\$username}<br />&nbsp;&nbsp;<input style="width: 95%;" type="text" class="textbox" name="username"/><br /><br />
-					{\$lang->password}<br />&nbsp;&nbsp;<input style="width: 95%;" type="password" class="textbox" name="password"/><br /><br />
-					<label title="{\$lang->remember_me_desc}"><input type="checkbox" class="checkbox" name="remember" value="yes"/> {\$lang->asb_welcome_remember_me}</label><br /><br />
+					{\$username}<br /><input style="width: 95%;" type="text" class="textbox" name="username"/><br /><br />
+					{\$lang->password}<br /><input style="width: 95%;" type="password" class="textbox" name="password"/><br /><br />
+					<label title="{\$lang->remember_me_desc}"><input type="checkbox" class="checkbox" name="remember" value="yes"/> {\$lang->remember_me}</label><br /><br />
 					<input type="submit" class="button" name="loginsubmit" value="{\$lang->login}"/>
 				</form>
 EOF

--- a/Upload/inc/plugins/asb/modules/welcome_box.php
+++ b/Upload/inc/plugins/asb/modules/welcome_box.php
@@ -30,7 +30,7 @@ function asb_welcome_box_info()
 		'title' => $lang->asb_welcome,
 		'description' => $lang->asb_welcome_desc,
 		'wrap_content' => true,
-		'version' => '1.3.3',
+		'version' => '1.3.4',
 		'compatibility' => '2.1',
 		'templates' => array(
 			array(
@@ -61,6 +61,7 @@ EOF
 				<span class="smalltext">{\$lang->asb_welcome_guest_welcome_registration}</span><br />
 				<br />
 				<form method="post" action="{\$mybb->settings[\'bburl\']}/member.php"><input type="hidden" name="action" value="do_login"/>
+					<input name="my_post_key" type="hidden" value="{\$mybb->post_code}" />
 					<input type="hidden" name="url" value="member.php"/>
 					{\$username}<br /><input style="width: 95%;" type="text" class="textbox" name="username"/><br /><br />
 					{\$lang->password}<br /><input style="width: 95%;" type="password" class="textbox" name="password"/><br /><br />

--- a/Upload/inc/plugins/asb/upgrade.php
+++ b/Upload/inc/plugins/asb/upgrade.php
@@ -113,6 +113,19 @@ if (version_compare($asbOldVersion, '3.1.7', '<')) {
 	));
 }
 
+/* < 3.1.12 */
+if (version_compare($asbOldVersion, '3.1.12', '<')) {
+	$removedForumFiles = array_merge($removedForumFiles, array(
+		'inc/plugins/asb/classes/WildcardPluginInstaller010202.php',
+		'inc/plugins/asb/classes/PortableObject010000.php',
+	));
+}
+
+/* < 3.1.13 */
+if (version_compare($asbOldVersion, '3.1.13', '<')) {
+	$removedForumFiles[] = 'inc/plugins/asb/classes/WildcardPluginInstaller010302.php';
+}
+
 if (!empty($removedForumFiles)) {
 	foreach ($removedForumFiles as $file) {
 		@unlink(MYBB_ROOT . $file);


### PR DESCRIPTION
**Fixes:**
- a bug where a query was wasted in the side box management page in ACP
- a bug where a query was wasted in the visibility tool tip display
- a bug where queries were wasted when building the theme list
- a bug where the Welcome module's login form was missing the authorization code and was broken
- a bug where the Welcome module's template reference a language variable that didn't exist
- a bug in the Birthdays module where if there were no birthdays for the given month, a SQL error occurred
- a bug where in the addon module functions, a PRE flag was used that was deprecated in PHP 7